### PR TITLE
Show only the D²MTOLab wordmark in the UI header

### DIFF
--- a/ui/main.py
+++ b/ui/main.py
@@ -1,5 +1,6 @@
 """DDMTOLab UI - Main entry point."""
 
+import re
 import sys
 from pathlib import Path
 
@@ -124,7 +125,13 @@ def _load_logo(parent):
             continue
         try:
             import cairosvg
-            png_data = cairosvg.svg2png(url=str(svg_logo), scale=3)
+            # The exported SVGs carry a baked-in "DDMTOLab" wordmark. The header
+            # draws its own D²MTOLab wordmark next to the mark, so strip any text
+            # from the asset first; otherwise both appear side by side. The PNG
+            # fallback is already mark-only, so this keeps the two paths identical.
+            svg_source = re.sub(r'<text\b.*?</text>', '',
+                                svg_logo.read_text(encoding='utf-8'), flags=re.S)
+            png_data = cairosvg.svg2png(bytestring=svg_source.encode('utf-8'), scale=3)
             img = Image.open(io.BytesIO(png_data)).convert("RGBA")
             # Crop to content area
             bbox = img.getbbox()


### PR DESCRIPTION
The UI header rendered two names side by side — the old `DDMTOLab` followed by `D²MTOLab`:


## Cause

`ui/assets/logo.svg` is a Visio export that carries a baked-in `DDMTOLab` wordmark — two `<text>` elements, a blurred shadow (`.st3`) and the light-coloured face (`.st5`):

```xml
<text x="7.9" y="577.01" class="st3">DDMTOLab</text>
<text x="7.9" y="577.01" class="st5">DDMTOLab</text>
```

`_load_logo` rasterises that SVG whole, and `_add_logo_wordmark` then draws its own `D²MTOLab` next to it, so both names appear.

The bug only shows up **where cairosvg is installed**. Without it the loader falls back to `logo.png`, which `generate_logo.py` builds from the mark polygons alone and therefore carries no text — which is why this went unnoticed.

## Fix

Strip `<text>` from the SVG before rasterising. This restores the intent already stated in `_load_logo`'s own docstring (*"design: mark then D²MTOLab"*) and makes the two loading paths render the same thing:

| | cropped size | aspect |
|---|---|---|
| SVG, before | 1287×392 | 3.28 (mark **+ wordmark**) |
| SVG, after | 390×392 | 1.00 (mark only) |
| PNG fallback | 238×240 | 0.99 (mark only) |

Filtering in the loader rather than editing the asset keeps the full Visio export intact, and also covers `logo_new.svg` — the preferred candidate in the lookup order — which carries the same wordmark.

Verified by reproducing `_load_logo`'s SVG branch directly and comparing the rendered images before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)