### PR TITLE
Simplify the 2026-07-23 News item

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 <!-- Rolling list: keep only the 5 most recent items, newest first. When adding a new item, delete the oldest so the list never exceeds 5. -->
 
-- **2026-07-23** — Aligned seven surrogate-assisted single-task algorithms (TLRBF, GL-SADE, AutoSAEA, DDEA-MESS, LSADE, SHPSO, SA-COSO) with their MATLAB reference implementations; added shared `newrbe`/`newrb` RBF surrogates.
+- **2026-07-23** — Verified and validated several surrogate-assisted single-task algorithms (TLRBF, GL-SADE, AutoSAEA, DDEA-MESS, LSADE, SHPSO, SA-COSO).
 - **2026-07-19** — Verified and validated several expensive multitask optimization algorithms (MFEA-SSG, BO-LCB-CKT, BO-LCB-BCKT, MUMBO, SELF, EEI-BO / EEI-BO+, SaEF-AKT, RAMTEA, LCB-EMT).
 
 ## 📖 Overview


### PR DESCRIPTION
The 2026-07-23 entry carried implementation detail the other News items do not — how the algorithms were aligned, and the shared RBF surrogates added along the way.

**Before**

> Aligned seven surrogate-assisted single-task algorithms (TLRBF, GL-SADE, AutoSAEA, DDEA-MESS, LSADE, SHPSO, SA-COSO) with their MATLAB reference implementations; added shared `newrbe`/`newrb` RBF surrogates.

**After**

> Verified and validated several surrogate-assisted single-task algorithms (TLRBF, GL-SADE, AutoSAEA, DDEA-MESS, LSADE, SHPSO, SA-COSO).

This mirrors the 2026-07-19 entry, so the list now reads consistently: which algorithms were covered, and nothing more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
