### PR TITLE
Let ParEGO-KT optimize single-objective tasks

### DIFF
--- a/src/ddmtolab/Algorithms/MTMO/ParEGO_KT.py
+++ b/src/ddmtolab/Algorithms/MTMO/ParEGO_KT.py
@@ -43,7 +43,7 @@ class ParEGO_KT:
         'n_tasks': '[2, K]',
         'dims': 'unequal',
         'objs': 'unequal',
-        'n_objs': '[2, M]',
+        'n_objs': '[1, M]',
         'cons': 'equal',
         'n_cons': '0',
         'expensive': 'True',

--- a/src/ddmtolab/Methods/Algo_Methods/uniform_point.py
+++ b/src/ddmtolab/Methods/Algo_Methods/uniform_point.py
@@ -76,7 +76,17 @@ def nbi_method(N: int, M: int) -> tuple[np.ndarray, int]:
         Weight vectors, shape (n_points, M)
     n_points : int
         Actual number of points generated
+
+    Notes
+    -----
+    For M = 1 the unit simplex degenerates to the single point [1.0], so one
+    weight vector is returned regardless of N. The layer search below cannot
+    reach that answer on its own: ``comb(H1 + 1, 0)`` is 1 for every H1, so its
+    loop condition never turns false.
     """
+    if M == 1:
+        return np.ones((1, 1)), 1
+
     # First layer
     H1 = 1
     while comb(H1 + M, M - 1, exact=True) <= N:
@@ -122,7 +132,18 @@ def ild_method(N: int, M: int) -> tuple[np.ndarray, int]:
         Weight vectors normalized to sum to 1, shape (n_points, M)
     n_points : int
         Actual number of points generated
+
+    Notes
+    -----
+    For M = 1 the unit simplex degenerates to the single point [1.0], so one
+    weight vector is returned regardless of N. The lattice loop below cannot
+    reach that answer on its own: with one dimension the edge filter
+    ``min(edge_W, axis=1) == 0`` always empties the frontier, so the point count
+    never grows past N.
     """
+    if M == 1:
+        return np.ones((1, 1)), 1
+
     I = M * np.eye(M)
     W = np.zeros((1, M))
     edge_W = W.copy()

--- a/tests/test_parego_kt_single_objective.py
+++ b/tests/test_parego_kt_single_objective.py
@@ -1,0 +1,172 @@
+"""
+Tests for single-objective support in ParEGO-KT.
+
+ParEGO scalarizes M objectives against a weight vector drawn from the unit
+simplex. For M = 1 that simplex degenerates to the single point [1.0], which
+the weight generator could not reach: both its NBI and ILD layer searches
+looped forever, so the algorithm hung before its first evaluation rather than
+failing. The scalarization itself is fine at M = 1 -- it reduces to the
+normalized objective -- so fixing the generator is all that single-objective
+support needs.
+
+The termination checks run in a daemon thread on purpose: a regression here
+hangs rather than raises, and a plain call would take the whole suite with it.
+"""
+
+import threading
+
+import numpy as np
+import pytest
+
+from ddmtolab.Algorithms.MTMO.ParEGO_KT import ParEGO_KT
+from ddmtolab.Methods.Algo_Methods.algo_utils import set_seed
+from ddmtolab.Methods.Algo_Methods.uniform_point import uniform_point
+from ddmtolab.Methods.mtop import MTOP
+
+TERMINATION_TIMEOUT = 30.0
+
+
+def call_with_timeout(func, *args, **kwargs):
+    """Run func in a daemon thread; return its result or None if it hangs."""
+    box = {}
+
+    def target():
+        box['result'] = func(*args, **kwargs)
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    thread.join(timeout=TERMINATION_TIMEOUT)
+    return None if thread.is_alive() else box.get('result')
+
+
+# =============================================================================
+# The weight generator
+# =============================================================================
+
+class TestUniformPointAtOneObjective:
+    """The degenerate simplex must resolve to its single point."""
+
+    @pytest.mark.parametrize('method', ['NBI', 'ILD', 'MUD'])
+    def test_terminates(self, method):
+        outcome = call_with_timeout(uniform_point, 100, 1, method=method)
+        assert outcome is not None, (
+            f"uniform_point(100, 1, method={method!r}) did not terminate within "
+            f"{TERMINATION_TIMEOUT}s"
+        )
+
+    @pytest.mark.parametrize('method', ['NBI', 'ILD', 'MUD'])
+    def test_every_weight_is_the_only_valid_one(self, method):
+        W, n = uniform_point(100, 1, method=method)
+        assert W.shape == (n, 1)
+        assert np.allclose(W, 1.0)
+        assert np.allclose(W.sum(axis=1), 1.0)
+
+    @pytest.mark.parametrize('method', ['NBI', 'ILD'])
+    def test_simplex_methods_return_exactly_one_weight(self, method):
+        # MUD is excluded: it honours its "exactly N points" contract and
+        # returns N copies, which is redundant but not wrong.
+        _, n = uniform_point(100, 1, method=method)
+        assert n == 1
+
+    @pytest.mark.parametrize('n_requested', [1, 10, 500])
+    def test_count_does_not_depend_on_the_request(self, n_requested):
+        _, n = uniform_point(n_requested, 1)
+        assert n == 1
+
+    @pytest.mark.parametrize('m', [2, 3, 5])
+    def test_more_objectives_are_untouched(self, m):
+        W, n = uniform_point(100, m)
+        assert W.shape == (n, m)
+        assert n > 1
+        assert np.allclose(W.sum(axis=1), 1.0, atol=1e-5)
+
+
+# =============================================================================
+# The algorithm
+# =============================================================================
+
+def single_objective_a(x):
+    return np.sum(x ** 2, axis=1, keepdims=True)
+
+
+def single_objective_b(x):
+    return np.sum((x - 0.3) ** 2, axis=1, keepdims=True) + 0.5
+
+
+def bi_objective(x):
+    return np.hstack([np.sum(x ** 2, axis=1, keepdims=True),
+                      np.sum((x - 1) ** 2, axis=1, keepdims=True)])
+
+
+N_INITIAL = 8
+MAX_NFES = 14
+
+
+def run_parego(funcs, seed=5):
+    problem = MTOP()
+    problem.add_task(funcs, dim=(3,) * len(funcs),
+                     lower_bound=(-2,) * len(funcs),
+                     upper_bound=(2,) * len(funcs))
+    set_seed(seed)
+    return ParEGO_KT(problem, n_initial=N_INITIAL, max_nfes=MAX_NFES, n_weights=10,
+                     save_data=False, disable_tqdm=True).optimize()
+
+
+@pytest.fixture(scope='module')
+def single_objective_run():
+    return run_parego((single_objective_a, single_objective_b))
+
+
+@pytest.fixture(scope='module')
+def mixed_run():
+    return run_parego((single_objective_a, bi_objective))
+
+
+class TestParEGOKTOnSingleObjectiveTasks:
+    """The capability the algorithm declares must actually hold."""
+
+    def test_declares_single_objective_support(self):
+        assert ParEGO_KT.algorithm_information['n_objs'] == '[1, M]'
+
+    def test_runs_to_the_requested_budget(self, single_objective_run):
+        assert list(single_objective_run.max_nfes) == [MAX_NFES, MAX_NFES]
+
+    def test_returns_a_best_individual_per_task(self, single_objective_run):
+        for best in single_objective_run.best_objs:
+            assert np.asarray(best).size == 1
+
+    def test_history_matches_the_reported_counts(self, single_objective_run):
+        lengths = [np.asarray(single_objective_run.all_objs[t][-1]).shape[0]
+                   for t in range(2)]
+        assert lengths == list(single_objective_run.max_nfes)
+
+    def test_it_actually_optimizes(self, single_objective_run):
+        """Terminating is not enough: the search must beat its initial design."""
+        for task in range(2):
+            history = np.asarray(single_objective_run.all_objs[task][-1]).ravel()
+            assert history.min() <= history[:N_INITIAL].min()
+
+    def test_no_nan_objectives(self, single_objective_run):
+        for task in range(2):
+            assert not np.isnan(np.asarray(single_objective_run.all_objs[task][-1])).any()
+
+
+class TestParEGOKTOnMixedObjectiveCounts:
+    """'objs': 'unequal' means one problem may mix M = 1 and M > 1 tasks."""
+
+    def test_runs_to_the_requested_budget(self, mixed_run):
+        assert list(mixed_run.max_nfes) == [MAX_NFES, MAX_NFES]
+
+    def test_single_objective_task_returns_an_individual(self, mixed_run):
+        assert np.asarray(mixed_run.best_objs[0]).size == 1
+
+    def test_multiobjective_task_returns_a_front(self, mixed_run):
+        assert np.asarray(mixed_run.best_objs[1]).shape == (MAX_NFES, 2)
+
+
+def test_multiobjective_still_works():
+    """Regression: the original multiobjective behaviour is unaffected."""
+    results = run_parego((bi_objective, bi_objective))
+    assert list(results.max_nfes) == [MAX_NFES, MAX_NFES]
+    for best in results.best_objs:
+        assert np.asarray(best).shape == (MAX_NFES, 2)


### PR DESCRIPTION
## What

`ParEGO_KT` now runs on single-objective tasks, and its `algorithm_information` declaration moves from `n_objs: '[2, M]'` to `'[1, M]'`.

## Why it was broken, and where

ParEGO scalarizes M objectives against a weight vector drawn from the unit simplex. At M = 1 that simplex degenerates to the single point `[1.0]` — but the weight generator could not reach it.

`nbi_method` searches for a layer count:

```python
H1 = 1
while comb(H1 + M, M - 1, exact=True) <= N:
    H1 += 1
```

At M = 1, `comb(H1 + 1, 0)` is `1` for every `H1`, so the condition `1 <= N` never turns false. `ild_method` fails the same way: its edge filter `min(edge_W, axis=1) == 0` always empties the frontier, so the point count never grows past `N`.

The consequence is the part worth noting for review: the algorithm **hung before its first evaluation** rather than raising. A capability declaration that is merely wrong usually surfaces as an exception; this one surfaced as a process that never returned, which is why `'[1, M]'` looked plausible.

## What changed

- `uniform_point.nbi_method` and `ild_method` return the single weight directly at M = 1.
- `mud_method` is **left alone**: it terminates and its values are correct, returning N copies of `[1.0]` under its own exactly-N-points contract. Redundant, not wrong.
- `ParEGO_KT` itself has **no logic change**. Its augmented Tchebycheff already degenerates correctly at M = 1 to `(1 + rho) * f_normalized`, which is monotone in the objective and so reduces the algorithm to plain EGO. Only the declaration line moves.

## Verification

| Check | Result |
|---|---|
| M = 1 terminates for NBI / ILD / MUD, all weights `[1.0]` | pass |
| M > 1 weight vectors byte-identical to before — 5 generation methods x M in {2,3,5} x N in {10,100,250}, diffed against `HEAD` | pass |
| Single-objective run: reaches budget, returns a best individual rather than a front, and **measurably improves** on its initial design (0.2077 -> 0.0063; 0.7569 -> 0.5066 where the optimum is 0.5) | pass |
| Mixed problem, one task M = 1 and another M = 2, as `'objs': 'unequal'` already promised | pass |
| All-multiobjective regression | pass |
| Full suite | 178 passed |

## Note for the reviewer

The termination tests in `tests/test_parego_kt_single_objective.py` run inside a daemon thread with a 30 s timeout. That is deliberate: this defect manifests as a hang, not an exception, so a plain call would take the entire test suite down with it instead of failing the one test.
